### PR TITLE
Add PDF splitting helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,18 @@ This repository stores concise notes on stochastic calculus.
 - `lecture-notes.pdf` contains the current lecture notes.
 - Notes on applications to finance and asset pricing are under development and will be added here as they are completed.
 
+## Splitting the lecture notes
+
+If you need separate PDFs per chapter, use `split_pdf.py` to extract page ranges.
+The script requires `PyPDF2` (install with `pip install PyPDF2`).
+
+Example:
+
+```bash
+python split_pdf.py lecture-notes.pdf 1-10 11-20 21-30
+```
+
+This creates `chapter1.pdf`, `chapter2.pdf`, and `chapter3.pdf` for the given
+page ranges. Chapter titles are not detected automatically—you must provide the
+page numbers manually.
+

--- a/split_pdf.py
+++ b/split_pdf.py
@@ -1,0 +1,47 @@
+import sys
+from typing import List, Tuple
+
+try:
+    from PyPDF2 import PdfReader, PdfWriter
+except ModuleNotFoundError:
+    sys.stderr.write("PyPDF2 is required to run this script.\n")
+    raise
+
+
+def parse_ranges(args: List[str]) -> List[Tuple[int, int]]:
+    ranges = []
+    for arg in args:
+        try:
+            start, end = map(int, arg.split('-'))
+        except ValueError:
+            raise ValueError(f"Invalid page range: {arg}")
+        if start < 1 or end < start:
+            raise ValueError(f"Invalid page range: {arg}")
+        ranges.append((start, end))
+    return ranges
+
+
+def split_pdf(src: str, ranges: List[Tuple[int, int]], output_prefix: str = "chapter") -> None:
+    reader = PdfReader(src)
+    for i, (start, end) in enumerate(ranges, 1):
+        writer = PdfWriter()
+        for p in range(start - 1, min(end, len(reader.pages))):
+            writer.add_page(reader.pages[p])
+        out_name = f"{output_prefix}{i}.pdf"
+        with open(out_name, "wb") as f:
+            writer.write(f)
+        print(f"Wrote {out_name}")
+
+
+def main(argv: List[str]) -> None:
+    if len(argv) < 3:
+        print("Usage: python split_pdf.py input.pdf start-end [start-end ...]")
+        print("Example: python split_pdf.py lecture-notes.pdf 1-10 11-20")
+        return
+    src = argv[1]
+    ranges = parse_ranges(argv[2:])
+    split_pdf(src, ranges)
+
+
+if __name__ == "__main__":
+    main(sys.argv)


### PR DESCRIPTION
## Summary
- add `split_pdf.py` to generate chapter PDFs
- document how to use the script in `README.md`

## Testing
- `python3 split_pdf.py lecture-notes.pdf 1-10` *(fails: ModuleNotFoundError: No module named 'PyPDF2')*

------
https://chatgpt.com/codex/tasks/task_e_684e721ddc54832e82aa819805941896